### PR TITLE
Allow the master to request more than one byte from the slave in a requestFrom() call

### DIFF
--- a/TinyWireS/examples/TinyWireS_Stress_Master/TinyWireS_Stress_Master.ino
+++ b/TinyWireS/examples/TinyWireS_Stress_Master/TinyWireS_Stress_Master.ino
@@ -1,0 +1,142 @@
+// ---------------------------------
+// Stress test program/example for TinyWireS I2C library.
+// Run this master program on the Arduino Uno R3.
+// Run the other slave program on the Attiny.
+// ---------------------------------
+// Written by Scott Hartog, 2/6/2016
+// This is the I2C master program which runs on on a regular Arduino
+// (not a AtTiny). This program uses the regular Wire library from the Arduino IDE.
+//
+// It performs these steps in a loop:
+//    1. picks a random number of bytes between 1 and 12
+//    2. sends that many bytes of random data to the AtTiny slave within
+//       a single Wire.beginTransmission() / Wire.write() / Wire.endTransmission() set
+//    3. reads that same number of bytes back with a single Wire.requestFrom() call
+//    4. compares the received data to the originally transmitted data
+//    5. displays the number of requests, number of requests with mismatches,
+//       and enough of the data so that the operator can tell it's working.
+//
+#include <Wire.h>
+
+// BREADBOARD SETUP:
+// Arduino Uno R3 (D18/SDA) = I2C SDA 
+//     connect to SDA on slave with external pull-up (~4.7K)
+// Arduino Uno R3 (D19/SCL) = I2C SCL 
+//     connect to SCL on slave with external pull-up (~4.7K)
+// Arduino Uno R3 (D2)
+//     connect to !RST on slave
+//     Can alternatively connect !RST on slave to the Ardiuno "!RESET" pin
+
+#define I2C_SLAVE_ADDR  0x26            // i2c slave address (38, 0x26)
+
+#define SLAVE_RESET_PIN 2
+
+uint16_t count = 0;       // total number of passes so far
+uint16_t error_count = 0; // total errors encountered so far
+
+char c_buf[64]; // for creating messages
+
+void setup()
+{
+  // set pin modes 
+  pinMode(SLAVE_RESET_PIN,OUTPUT);
+
+  // init the serial port
+  Serial.begin(115200);
+
+  // print some useful pinnout info for the Arduino
+  //Serial.println(String("SCL:")+String(SCL)+String(", SDA:")+String(SDA));
+  //Serial.println(String("MOSI:")+String(MOSI)+String(", SCK:")+String(SCK));
+
+  // init the Wire object (for I2C)
+  Wire.begin(); 
+  
+  // reset the slave
+  digitalWrite(SLAVE_RESET_PIN, LOW);
+  delay(10);
+  digitalWrite(SLAVE_RESET_PIN, HIGH);
+  
+  // wait for slave to finish any init sequence
+  delay(2000);
+}
+
+void loop()
+{
+  uint8_t i;
+  uint8_t req_rtn;       // num bytes returned by requestFrom() call
+  uint8_t rand_byte_count;
+  uint8_t out_rand[16];  // data written from master
+  uint8_t in_rand[16];   // data read back from slave
+
+  bool mismatch;
+
+  // count total number of request
+  count++;
+
+  // compute random number of bytes for this pass
+  rand_byte_count = random(12) + 1;
+
+  // force the first three requests to be small so that the tx buffer doesn't overflow
+  // instantly and the user can see at least one successful transaction and some
+  // mismtaches before the usiTwiSlave.c library hangs on the line "while ( tmphead == txTail );".
+  if (count <= 3) rand_byte_count = 2;
+
+  // generate, save, and send N random byte values
+  Wire.beginTransmission(I2C_SLAVE_ADDR);
+  for (i = 0; i < rand_byte_count; i++)
+    Wire.write(out_rand[i] = random(256));
+  Wire.endTransmission();
+  
+  //delay (10);  // optional delay if required by slave (like sample ADC)
+
+  // read N bytes from slave
+  req_rtn = Wire.requestFrom(I2C_SLAVE_ADDR, (int)rand_byte_count);      // Request N bytes from slave
+  for (i = 0; i < req_rtn; i++)
+    in_rand[i] = Wire.read();
+
+  // compare in/out data values
+  mismatch = false;
+  for (i = 0; i < rand_byte_count; i++)
+    mismatch = mismatch || (out_rand[i] != in_rand[i]);
+
+  // increment the error counter if the number of byte variables don't match or
+  // if the data itself doesn't match
+  if (mismatch || (rand_byte_count != req_rtn)) error_count++;
+
+  // The rest of the program just displays the results
+  
+  // display total requests so far and error count so far
+  snprintf(c_buf, sizeof(c_buf), "req: %3d,err: %3d", count, error_count);
+  Serial.println(c_buf);
+
+  // display the random byte count, the number of bytes read back, and "MATCH"/"MISMATCH"
+  snprintf(c_buf, sizeof(c_buf), "size: %2d/%2d,%s", rand_byte_count, req_rtn, rand_byte_count != req_rtn?"MISMATCH  <<--- !!!":"MATCH");
+  Serial.println(c_buf);
+  
+  // display whether the data compare matched or mismatched
+  snprintf(c_buf, sizeof(c_buf), "data: %s", mismatch?"MISMATCH  <<--- !!!":"MATCH");
+  Serial.println(c_buf);
+
+  // send up to three tx/rx bytes so that random data can be
+  // visually verified
+  if (rand_byte_count >= 1)
+  {
+    snprintf(c_buf, sizeof(c_buf), "rand[0]: %02x/%02x", out_rand[0], in_rand[0]);
+    Serial.println(c_buf);
+  }
+
+  if (rand_byte_count >= 2)
+  {
+    snprintf(c_buf, sizeof(c_buf), "rand[1]: %02x/%02x", out_rand[1], in_rand[1]);
+    Serial.println(c_buf);
+  }
+
+  if (rand_byte_count >= 3)
+  {
+    snprintf(c_buf, sizeof(c_buf), "rand[2]: %02x/%02x", out_rand[2], in_rand[2]);
+    Serial.println(c_buf);
+  }
+
+  // delay 1 second so user can watch results
+  delay(1000);
+}

--- a/TinyWireS/examples/TinyWireS_Stress_Slave/TinyWireS_Stress_Slave.ino
+++ b/TinyWireS/examples/TinyWireS_Stress_Slave/TinyWireS_Stress_Slave.ino
@@ -1,0 +1,104 @@
+// ---------------------------------
+// Stress test program/example for TinyWireS I2C library.
+// Run this slave program on the Attiny.
+// Run the other master program on the Arduino Uno R3.
+// ---------------------------------
+// // Written by Scott Hartog, 2/6/2016, to stress test the TinyWireS library.
+// https://github.com/rambo/TinyWire
+//
+// This project uses the Tiny85 as an I2C slave.
+//
+// The slave program using TinyWireS, running on a Attiny85, receives
+// N bytes of random data in a single receiveEvent() callback and
+// stores that data in a global buffer. It then responds the first requestEvent()
+// callback with that same data. The requestEvent() callback overwrites the data
+// buffer with zeros after responding so it will only respond correctly to the
+// first requestEvent() callback after each receiveEvent() callback. Subsequent
+// requestEvent() will respond with 0xff for all data bytes.
+//
+//
+// SETUP:
+// AtTiny Pin 5 (PB0/SDA) = I2C SDA 
+//     connect to SDA on master with external pull-up (~4.7K)
+// AtTiny Pin 7 (PB0/SCL) = I2C SCL 
+//     connect to SCL on master with external pull-up (~4.7K)
+// AtTiny Pin 1 (PB5/!RST)
+//     connect to reset on master (or just pull-up)
+//
+// Please see credits and usage for usiTwiSlave and TinyWireS in the .h files of 
+// those libraries.
+
+#include "TinyWireS.h"                  // wrapper class for I2C slave routines
+
+#define I2C_SLAVE_ADDR  0x26            // i2c slave address (38, 0x26)
+
+// global buffer to store data sent from the master.
+uint8_t master_data[16];
+// global variable to number of bytes sent from the master.
+uint8_t master_bytes;
+
+// Gets called when the ATtiny receives an i2c write slave request
+void receiveEvent(uint8_t num_bytes)
+{
+  uint8_t i;
+  
+  // save the number of bytes sent from the master
+  master_bytes = num_bytes;
+
+  // store the data from the master into the data buffer
+  for (i = 0; i < master_bytes; i++)
+    master_data[i] = TinyWireS.receive();
+
+}
+
+// Gets called when the ATtiny receives an i2c read slave request
+void requestEvent()
+{
+  uint8_t i;
+  
+  // send the data buffer back to the master
+  for (i = 0; i < master_bytes; i++)
+    TinyWireS.send(master_data[i]);
+
+  // corrupt the byte values in the data buffer
+  // so that subsequent call won't match
+  for (i = 0; i < master_bytes; i++)
+    master_data[i] += 0x5a;
+
+  // corrupt length of the request, but dont' make it zero
+  
+  // if the usiTwiSlave.c is working fine, then this number is completely irrelevant
+  // because the requestEvent() callback will not be called again until
+  // after the next receiveEvent() callback, so the master_data and
+  // master_bytes variables will be set by that call.
+
+  // If the usiTwiSlave.c has the issue of calling the requestFrom() callback
+  // for each byte sent, the buffer will accumulate by this amount *for each byte
+  // in the original request*.
+  // 
+  // Making it zero will obscure the 1-byte send issue in the usiTwiSlave.c
+  // that is being tested.
+  // Making it small will allow a few requests to succeed before the tx buffer
+  // overflows and the usiTwiSlave.c hangs on the "while ( tmphead == txTail );"
+  // line
+  master_bytes = 2; 
+}
+
+void setup()
+{
+  // initialize the TinyWireS and usiTwiSlave libraries
+  TinyWireS.begin(I2C_SLAVE_ADDR);      // init I2C Slave mode
+
+  // register the onReceive() callback function
+  TinyWireS.onReceive(receiveEvent);
+  
+  // register the onRequest() callback function
+  TinyWireS.onRequest(requestEvent);
+}
+
+void loop()
+{
+  // This needs to be here
+  TinyWireS_stop_check();  
+  // otherwise empty loop
+}

--- a/TinyWireS/usiTwiSlave.c
+++ b/TinyWireS/usiTwiSlave.c
@@ -581,6 +581,7 @@ ISR( USI_OVERFLOW_VECTOR )
          if(_onTwiDataRequest) _onTwiDataRequest();
          if ( USIDR & 0x01 )
         {
+          USI_REQUEST_CALLBACK();
           overflowState = USI_SLAVE_SEND_DATA;
         }
         else
@@ -610,7 +611,6 @@ ISR( USI_OVERFLOW_VECTOR )
     // copy data from buffer to USIDR and set USI to shift byte
     // next USI_SLAVE_REQUEST_REPLY_FROM_SEND_DATA
     case USI_SLAVE_SEND_DATA:
-      USI_REQUEST_CALLBACK();
       // Get data from Buffer
       if ( txHead != txTail )
       {


### PR DESCRIPTION
All this is actually from @rshartog but I had to do a bit of cleanup to the commit history.

Summary: To allow the master to request more than one byte from the slave in a requestFrom() call, the USI_REQUEST_CALLBACK() call on line 613 of the current usiTwiSlave.c code should be moved to line 583.

Explanation: For the current code, the ISR routine correctly sends the execution through the “USI_SLAVE_SEND_DATA” case-branch for each byte sent from the slave to the master. With the USI_REQUEST_CALLBACK() on line 613, the callback routine is called for *each byte* that the master requests. Assuming the callback should queue the send data for the entire request, then the current code generates N bytes of data for each byte sent (N^2 bytes total) and only removes N bytes from the transmit buffer. This works when N==1, but if N>1 this quickly results in a transmit buffer overflow and execution hangs on line 406. (This behavior was observed by having the slave respond with the values of txHead and txTail until the slave hung on line 406.)

If you move USI_REQUEST_CALLBACK() to line 583, then the callback is called only once per master request (when the request is initially received).

One other related note: As written, the useable size of the rxBuf is actually TWI_RX_BUFFER_SIZE - 1. Same for txBuf/TWI_TX_BUFFER_SIZE. This is because the Head pointer cannot fully wrap back to the value of the Tail pointer. (Doing so would appear to be an empty buffer.) This detail might be important to someone who thinks they can use the entire buffer.

Sketches to stress-test the functionality have been provided.