### PR TITLE
corrected link hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with Arduinos TWI hardware that is known to implement I2C properly.
 
 [i2crepl]: https://github.com/rambo/I2C/blob/master/examples/i2crepl/i2crepl.ino
 [rpibug]: http://www.advamation.com/knowhow/raspberrypi/rpi-i2c-bug.html
-[pigpio]: http://abyz.co.uk/rpi/pigpio/python.html#bb_i2c_zip
+[pigpio]: http://abyz.me.uk/rpi/pigpio/python.html#bb_i2c_zip
 [pigtip]: https://github.com/rambo/TinyWire/issues/14#issuecomment-125325081
 
 ## delayMicroseconds


### PR DESCRIPTION
The old link was going to an advertising site.